### PR TITLE
Added sample test for alert handling

### DIFF
--- a/test_system/database.ts
+++ b/test_system/database.ts
@@ -1,4 +1,5 @@
 import { getConnection } from '../src/database/connection';
+import { Alert } from '../src/database/entity/alert';
 
 export async function cleanDatabase(): Promise<void> {
   try {
@@ -11,5 +12,33 @@ export async function cleanDatabase(): Promise<void> {
     await connection.query(`TRUNCATE ${tableNames} CASCADE;`);
   } catch (error) {
     throw new Error(`ERROR: Cleaning test database: ${error}`);
+  }
+}
+
+export async function getAlerts(
+  flow_name: string,
+  action_name: string
+): Promise<Alert[]> {
+  const ALERT_TABLE_NAME: string = 'alert';
+  try {
+    const connection = await getConnection();
+    const entities = connection.entityMetadatas;
+    const table = entities.find(
+      entity => entity.tableName === ALERT_TABLE_NAME
+    );
+    return await connection.query(
+      `SELECT 
+        flow_name, 
+        action, 
+        test_result_id 
+      FROM ${table?.schema}.${table?.tableName} 
+      WHERE 
+        flow_name='${flow_name}' 
+        AND action='${action_name}'`
+    );
+  } catch (error) {
+    throw new Error(
+      `ERROR: Getting the alerts from database. ${error.message}`
+    );
   }
 }

--- a/test_system/helper.ts
+++ b/test_system/helper.ts
@@ -26,11 +26,11 @@ function createTestResultOutput(
     product: product,
     testType: testType,
     cpuTime: Math.floor(Math.random() * 250 + 100),
-    dmlRows: 100,
+    dmlRows: 50,
     dmlStatements: 50,
-    heapSize: 5000,
-    queryRows: 200,
-    soqlQueries: 10,
+    heapSize: 75,
+    queryRows: 0,
+    soqlQueries: 0,
   };
 }
 

--- a/test_system/helper.ts
+++ b/test_system/helper.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import { TestResult, Timer } from '../src';
+import { saveTestResult } from '../src/database/testResult';
+import {
+  convertOutputToTestResult,
+  TestResultOutput,
+} from '../src/services/result/output';
+
+// Count of test result will store in the database.
+const NUMBER_OF_TEST_RESULT = 5;
+
+// This method will return test result object.
+function createTestResultOutput(
+  action: string,
+  flowName: string,
+  product: string,
+  testType: string
+): TestResultOutput {
+  return {
+    timer: new Timer('1000'),
+    action: action,
+    flowName: flowName,
+    product: product,
+    testType: testType,
+    cpuTime: Math.floor(Math.random() * 250 + 100),
+    dmlRows: 100,
+    dmlStatements: 50,
+    heapSize: 5000,
+    queryRows: 200,
+    soqlQueries: 10,
+  };
+}
+
+// This method will convert Test result output array to Test result array.
+function bulkConversionToTestResult(
+  inputTestResults: TestResultOutput[]
+): TestResult[] {
+  return inputTestResults.map((inputTestResult: TestResultOutput) =>
+    convertOutputToTestResult(inputTestResult)
+  );
+}
+
+export async function createSampleAlertTestData(
+  action: string,
+  flowName: string,
+  product: string,
+  testType: string
+) {
+  const inputTestResults: TestResultOutput[] = [
+    ...Array(NUMBER_OF_TEST_RESULT),
+  ].map(() => {
+    return createTestResultOutput(action, flowName, product, testType);
+  });
+  const sampleTestResults: TestResult[] =
+    bulkConversionToTestResult(inputTestResults);
+  await saveTestResult(sampleTestResults);
+}

--- a/test_system/sampleAlert/alert.apex
+++ b/test_system/sampleAlert/alert.apex
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+// Start collecting initial governor limits
+GovernorLimits initialLimits = (new GovernorLimits()).getCurrentGovernorLimits();
+
+// --- Place your code to be tested here ---
+for(Integer i=0; i<150; i++) {
+  insert new Account(Name='Test Account');
+}
+
+// End collecting final governor limits
+GovernorLimits finalLimits = (new GovernorLimits()).getCurrentGovernorLimits();
+
+// Calculate the difference between initial and final governor limits
+GovernorLimits limitsDiff = (new GovernorLimits()).getLimitsDiff(initialLimits, finalLimits);
+
+// Serialize and display the governor limits difference
+System.assert(false, '-_' + JSON.serialize(limitsDiff) + '_-');

--- a/test_system/sampleAlert/sampleAlert.test.ts
+++ b/test_system/sampleAlert/sampleAlert.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2025 Certinia Inc. All rights reserved.
+ */
+
+import { expect } from 'chai';
+import {
+  AlertInfo,
+  createApexExecutionTestStepFlow,
+  saveResults,
+  Thresholds,
+  TransactionProcess,
+  TransactionTestTemplate,
+} from '../../src';
+import { Alert } from '../../src/database/entity/alert';
+import { cleanDatabase, getAlerts } from '../database';
+import { createSampleAlertTestData } from '../helper';
+import { config } from 'dotenv';
+
+describe('Sample Test For Alert Handling', () => {
+  let test: TransactionTestTemplate;
+  config();
+
+  before(async () => {
+    await cleanDatabase();
+    test = await TransactionProcess.build('testProduct');
+
+    if (process.env.STORE_ALERTS === undefined) {
+      process.env.STORE_ALERTS = 'true';
+    }
+
+    await createSampleAlertTestData(
+      'testActionOne',
+      'sampleTestFlow',
+      'testProduct',
+      'unitTest'
+    );
+    await createSampleAlertTestData(
+      'testActionTwo',
+      'sampleTestFlow',
+      'testProduct',
+      'unitTest'
+    );
+    await createSampleAlertTestData(
+      'testActionThree',
+      'sampleTestFlow',
+      'testProduct',
+      'unitTest'
+    );
+  });
+
+  it('should create alert when we used default threshold and store alerts.', async () => {
+    // Act
+    await TransactionProcess.executeTestStep(
+      test,
+      await createApexExecutionTestStepFlow(
+        test.connection,
+        __dirname + '/alert.apex',
+        { flowName: 'sampleTestFlow', action: 'testActionOne' }
+      )
+    );
+    await saveResults(test, test.flowStepsResults);
+
+    // Assert
+    const alert: Alert[] = await getAlerts('sampleTestFlow', 'testActionOne');
+    expect(alert).to.be.ok;
+    expect(
+      alert,
+      `Alert is expected to be an array but it is ${typeof alert}`
+    ).to.be.a('array');
+    expect(
+      alert,
+      `Alert is expected to have 1 item but it contains ${alert.length}.`
+    ).to.have.lengthOf(1);
+    expect(alert.at(0)?.flow_name).to.be.equal('sampleTestFlow');
+    expect(alert.at(0)?.action).to.be.equal('testActionOne');
+  });
+
+  it('should create alert when we provide a custom threshold and store alerts as true.', async () => {
+    // Arrange
+    const customThresolds: Thresholds = new Thresholds();
+    customThresolds.cpuTimeThreshold = 0;
+    customThresolds.dmlRowThreshold = 0;
+    customThresolds.dmlStatementThreshold = 10;
+    customThresolds.heapSizeThreshold = 0;
+    customThresolds.queryRowsThreshold = 0;
+    customThresolds.soqlQueriesThreshold = 0;
+
+    const alertInfo: AlertInfo = new AlertInfo();
+    alertInfo.storeAlerts = true;
+    alertInfo.thresolds = customThresolds;
+
+    // Act
+    await TransactionProcess.executeTestStep(
+      test,
+      await createApexExecutionTestStepFlow(
+        test.connection,
+        __dirname + '/alert.apex',
+        { flowName: 'sampleTestFlow', action: 'testActionTwo' }
+      ),
+      alertInfo
+    );
+    await saveResults(test, test.flowStepsResults);
+
+    // Assert
+    const alert: Alert[] = await getAlerts('sampleTestFlow', 'testActionTwo');
+    expect(alert).to.be.ok;
+    expect(
+      alert,
+      `Alert is expected to be an array but it is ${typeof alert}`
+    ).to.be.a('array');
+    expect(
+      alert,
+      `Alert is expected to have 1 item but it contains ${alert.length}.`
+    ).to.have.lengthOf(1);
+    expect(alert.at(0)?.flow_name).to.be.equal('sampleTestFlow');
+    expect(alert.at(0)?.action).to.be.equal('testActionTwo');
+  });
+
+  it('should not create alert when we set store alerts as false.', async () => {
+    // Arrange
+    const alertInfo: AlertInfo = new AlertInfo();
+    alertInfo.storeAlerts = false;
+
+    // Act
+    await TransactionProcess.executeTestStep(
+      test,
+      await createApexExecutionTestStepFlow(
+        test.connection,
+        __dirname + '/alert.apex',
+        { flowName: 'sampleTestFlow', action: 'testActionThree' }
+      ),
+      alertInfo
+    );
+    await saveResults(test, test.flowStepsResults);
+
+    // Assert
+    const alert: Alert[] = await getAlerts('sampleTestFlow', 'testActionThree');
+    expect(alert).to.be.ok;
+    expect(
+      alert,
+      `Alert is expected to be an array but it is ${typeof alert}`
+    ).to.be.a('array');
+    expect(
+      alert,
+      `expected to have 0 item in alert array but received ${alert.length}.`
+    ).to.have.lengthOf(0);
+    expect(alert.at(0)?.flow_name).to.be.equal(undefined);
+    expect(alert.at(0)?.action).to.be.equal(undefined);
+  });
+});

--- a/test_system/sampleAlert/sampleAlert.test.ts
+++ b/test_system/sampleAlert/sampleAlert.test.ts
@@ -147,7 +147,5 @@ describe('Sample Test For Alert Handling', () => {
       alert,
       `expected to have 0 item in alert array but received ${alert.length}.`
     ).to.have.lengthOf(0);
-    expect(alert.at(0)?.flow_name).to.be.equal(undefined);
-    expect(alert.at(0)?.action).to.be.equal(undefined);
   });
 });

--- a/test_system/sampleAlert/sampleAlert.test.ts
+++ b/test_system/sampleAlert/sampleAlert.test.ts
@@ -31,19 +31,19 @@ describe('Sample Test For Alert Handling', () => {
       'testActionOne',
       'sampleTestFlow',
       'testProduct',
-      'unitTest'
+      'Transaction Process'
     );
     await createSampleAlertTestData(
       'testActionTwo',
       'sampleTestFlow',
       'testProduct',
-      'unitTest'
+      'Transaction Process'
     );
     await createSampleAlertTestData(
       'testActionThree',
       'sampleTestFlow',
       'testProduct',
-      'unitTest'
+      'Transaction Process'
     );
   });
 

--- a/test_system/sampleAlert/sampleAlert.test.ts
+++ b/test_system/sampleAlert/sampleAlert.test.ts
@@ -22,7 +22,6 @@ describe('Sample Test For Alert Handling', () => {
 
   before(async () => {
     await cleanDatabase();
-    test = await TransactionProcess.build('testProduct');
 
     if (process.env.STORE_ALERTS === undefined) {
       process.env.STORE_ALERTS = 'true';
@@ -46,6 +45,10 @@ describe('Sample Test For Alert Handling', () => {
       'testProduct',
       'unitTest'
     );
+  });
+
+  beforeEach(async () => {
+    test = await TransactionProcess.build('testProduct');
   });
 
   it('should create alert when we used default threshold and store alerts.', async () => {


### PR DESCRIPTION
I have added three test scenarios for alert handling.
> create alert when we used default threshold and store alerts.
> create alert when we provide a custom threshold and store alerts as true.
> not create alert when we set store alerts as false.